### PR TITLE
Adds 'smtp' to valid TRANSPORT values

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This is the list of available configuration options:
 | `MICROSERVICE_PORT` | Port number for the standalone application. If not specified it will run in a random port |
 | `DEFAULT_FROM` | Default email sender if a `from` parameter is not specified |
 | `DEFAULT_LANGUAGE` | Default language to be used if a `language` is not specified. Defaults to `en` |
-| `TRANSPORT` | Third-party service to be used to send the email. Supported values: [`ses`, `sendgrid`, `postmark`, `mailgun`] for production; `stub` for testing |
+| `TRANSPORT` | Third-party service to be used to send the email. Supported values: [`ses`, `sendgrid`, `postmark`, `mailgun`, 'smtp'] for production; `stub` for testing |
 | `AWS_KEY` | AWS Key for sending emails using Amazon SES |
 | `AWS_SECRET` | AWS Secret for sending emails using Amazon SES |
 | `AWS_REGION` | AWS Region for sending emails using Amazon SES |


### PR DESCRIPTION
Realized this was missing when reading through the code, figured it's useful to add for others.