### PR TITLE
Adds ability to add global template options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const winston = require('winston')
 
+let globalTemplateOptions = {}
+
 const Joi = require('joi')
 
 const schema = Joi.object().keys({
@@ -33,11 +35,16 @@ exports.createRouter = (config = {}) => {
       templateOptions,
       language
     } = req.body
-    service.sendTemplatedEmail(emailOptions, templateName, templateOptions, language)
+    const mergedTemplateOptions = { ...globalTemplateOptions, ...templateOptions }
+    service.sendTemplatedEmail(emailOptions, templateName, mergedTemplateOptions, language)
       .then(response => res.json(response))
       .catch(err => res.status(500).json({ error: err.message || String(err) }))
   })
   return router
+}
+
+exports.setGlobalTemplateOptions = (templateOptions) => {
+  globalTemplateOptions = templateOptions
 }
 
 exports.startServer = (config, callback) => {

--- a/test/spec.js
+++ b/test/spec.js
@@ -7,6 +7,7 @@ const fetch = require('./_fetch')
 
 const env = require('../src/utils/env')()
 const email = require('../src/email')(env)
+const index = require('../')
 
 test('render template with ejs body', t => {
   return email.processTemplate('ejsbody', { user: { name: 'John' } }, 'en')
@@ -56,6 +57,38 @@ test('successful rest API call', t => {
     body: {
       language: 'en',
       templateName: 'pugbody',
+      templateOptions: {
+        user: { name: 'John' }
+      },
+      emailOptions: {
+        from: 'Judy <judy@example.com>',
+        to: 'John <john@example.com>'
+      }
+    }
+  })
+  .then(response => {
+    t.is(response.status, 200)
+    return response.json()
+  })
+  .then(body => {
+    t.truthy(body.messageId)
+    t.deepEqual(body.envelope, { from: 'judy@example.com', to: [ 'john@example.com' ] })
+  })
+})
+
+test('successful rest API call with global template options', t => {
+  // Set our global_template_option variable, fails without it.
+  index.setGlobalTemplateOptions({
+    global_template_option: {
+      test: 'a global template option'
+    }
+  })
+
+  return fetch('/email/send', {
+    method: 'POST',
+    body: {
+      language: 'en',
+      templateName: 'global_template_option_test',
       templateOptions: {
         user: { name: 'John' }
       },

--- a/test/templates/en/global_template_option_test-body-text.ejs
+++ b/test/templates/en/global_template_option_test-body-text.ejs
@@ -1,0 +1,4 @@
+Welcome <%= user.name %>
+<%= global_template_option.test %>
+
+Cheers,

--- a/test/templates/en/global_template_option_test-html.ejs
+++ b/test/templates/en/global_template_option_test-html.ejs
@@ -1,0 +1,8 @@
+<style>
+  h1 { color: #777 }
+</style>
+
+<h1>Welcome <%= user.name %></h1>
+<h1><%= global_template_option.test %></h1>
+
+<p>Cheers,</p>

--- a/test/templates/en/global_template_option_test-subject.ejs
+++ b/test/templates/en/global_template_option_test-subject.ejs
@@ -1,0 +1,1 @@
+Welcome <%- user.name %>


### PR DESCRIPTION
This is my crack at #8. 

This introduces a new exported function to index.js called `setGlobalTemplateOptions`. These template options are available to all templates so that clients of the email service don't need to include extra variables that they might not need to be responsible for. 

Happy to make any edits and add this to the README if you folks would like it to get merged. Thanks!